### PR TITLE
Event Store persists causation_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- The event store persists the event `causation_id`. To facilitate this
+  a `causation_id` column has been added to the `events` table and the
+  `write_events` function has been altered. Event Sourcery apps will need
+  to ensure these DB changes have been applied to use this version of
+  Event Sourcery.
+
 ## [0.2.0] - 2017-6-1
 ### Changed
 - Make `EventSourcery::Postgres::OptimisedEventPollWaiter#shutdown` private

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -94,6 +94,7 @@ module EventSourcery
         types = sql_literal_array(events, 'varchar', &:type)
         created_ats = sql_literal_array(events, 'timestamp without time zone', &:created_at)
         event_uuids = sql_literal_array(events, 'uuid', &:uuid)
+        causation_ids = sql_literal_array(events, 'uuid', &:causation_id)
         <<-SQL
           select #{@write_events_function_name}(
             #{sql_literal(aggregate_id, 'uuid')},
@@ -102,6 +103,7 @@ module EventSourcery
             #{bodies},
             #{created_ats},
             #{event_uuids},
+            #{causation_ids},
             #{sql_literal(@lock_table, 'boolean')}
           );
         SQL

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -17,12 +17,12 @@ module EventSourcery
         db.run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
         db.create_table(table_name) do
           primary_key :id, type: :Bignum
-          column :uuid, 'uuid default uuid_generate_v4() not null'
-          column :aggregate_id, 'uuid not null'
-          column :type, 'varchar(255) not null'
-          column :body, 'json not null'
-          column :version, 'bigint not null'
-          column :created_at, 'timestamp without time zone not null default (now() at time zone \'utc\')'
+          column :uuid,           :uuid,    null: false, default: Sequel.lit('uuid_generate_v4()')
+          column :aggregate_id,   :uuid,    null: false
+          column :type,           :varchar, null: false, size: 255
+          column :body,           :json,    null: false
+          column :version,        :bigint,  null: false
+          column :created_at,     :'timestamp without time zone', null: false, default: Sequel.lit("(now() at time zone 'utc')")
           index [:aggregate_id, :version], unique: true
           index :uuid, unique: true
           index :type
@@ -33,8 +33,8 @@ module EventSourcery
       def create_aggregates(db: EventSourcery::Postgres.config.event_store_database,
                             table_name: EventSourcery::Postgres.config.aggregates_table_name)
         db.create_table(table_name) do
-          primary_key :aggregate_id, 'uuid not null'
-          column :version, 'bigint default 1'
+          primary_key :aggregate_id, :uuid
+          column :version, :bigint, default: 1
         end
       end
 

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -44,7 +44,7 @@ module EventSourcery
                                      events_table_name: EventSourcery::Postgres.config.events_table_name,
                                      aggregates_table_name: EventSourcery::Postgres.config.aggregates_table_name)
         db.run <<-SQL
-create or replace function #{function_name}(_aggregateId uuid, _eventTypes varchar[], _expectedVersion int, _bodies json[], _createdAtTimes timestamp without time zone[], _eventUUIDs uuid[], _lockTable boolean) returns void as $$
+create or replace function #{function_name}(_aggregateId uuid, _eventTypes varchar[], _expectedVersion int, _bodies json[], _createdAtTimes timestamp without time zone[], _eventUUIDs uuid[], _causationIds uuid[], _lockTable boolean) returns void as $$
 declare
 currentVersion int;
 body json;
@@ -104,9 +104,9 @@ loop
   end if;
 
   insert into #{events_table_name}
-    (uuid, aggregate_id, type, body, version, created_at)
+    (uuid, aggregate_id, type, body, version, causation_id, created_at)
   values
-    (_eventUUIDs[index], _aggregateId, _eventTypes[index], body, eventVersion, createdAt)
+    (_eventUUIDs[index], _aggregateId, _eventTypes[index], body, eventVersion, _causationIds[index], createdAt)
   returning id into eventId;
 
   eventVersion := eventVersion + 1;

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -22,6 +22,7 @@ module EventSourcery
           column :type,           :varchar, null: false, size: 255
           column :body,           :json,    null: false
           column :version,        :bigint,  null: false
+          column :causation_id,   :uuid
           column :created_at,     :'timestamp without time zone', null: false, default: Sequel.lit("(now() at time zone 'utc')")
           index [:aggregate_id, :version], unique: true
           index :uuid, unique: true


### PR DESCRIPTION
### Context

In https://github.com/envato/event_sourcery/pull/157 we added a `causation_id` attribute to the `Event` class and added the expectation that all Event Sourcery event stores will persist this value.

### Change

Update the PostgreSQL event store so that it persists the `causation_id` event attribute. This includes adding a column to the `events` table and updating the `write_events` function to populate it.

### Considerations

We'll need to ensure that all Event Sourcery applications make this schema change when upgrading to the next version of Event Sourcery. Is the entry to the change log enough notice?

Although there are no specs added here. There is some covering this change in the event store shared RSpec examples provided by the `event_sourcery` gem. The build will be broken till this change is applied.

In a subsequent PR we'll populate this `causation_id` with the UUID of the event being reacted when emitting events from reactors. This will replace the `_driven_by_event_id` currently being populated in event bodies.