### PR TITLE
Make things little neater and or idiomatic

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -4,37 +4,37 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'event_sourcery/postgres/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "event_sourcery-postgres"
+  spec.name          = 'event_sourcery-postgres'
   spec.version       = EventSourcery::Postgres::VERSION
   # TODO: update authors
-  spec.authors       = ["Steve Hodgkiss"]
-  spec.email         = ["steve@hodgkiss.me"]
+  spec.authors       = ['Steve Hodgkiss']
+  spec.email         = ['steve@hodgkiss.me']
 
-  spec.summary       = %q{Postgres event store for use with EventSourcery}
-  spec.homepage      = "https://github.com/envato/event_sourcery-postgres"
+  spec.summary       = 'Postgres event store for use with EventSourcery'
+  spec.homepage      = 'https://github.com/envato/event_sourcery-postgres'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'sequel', '~> 4.38'
   spec.add_dependency 'pg'
   spec.add_dependency 'event_sourcery', '>= 0.10.0'
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "benchmark-ips"
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'benchmark-ips'
 end

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -101,7 +101,7 @@ module EventSourcery
 
       def sql_literal_array(events, type, &block)
         sql_array = events.map do |event|
-         to_sql_literal(block.call(event))
+          to_sql_literal(yield event)
         end.join(', ')
         "array[#{sql_array}]::#{type}[]"
       end

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -44,9 +44,7 @@ module EventSourcery
 
       def latest_event_id(event_types: nil)
         latest_event = events_table
-        if event_types
-          latest_event = latest_event.where(type: event_types)
-        end
+        latest_event = latest_event.where(type: event_types) if event_types
         latest_event = latest_event.order(:id).last
         if latest_event
           latest_event[:id]

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -113,12 +113,12 @@ module EventSourcery
       def to_sql_literal(value)
         return 'null' unless value
         wrapped_value = if Time === value
-          value.iso8601(6)
-        elsif Hash === value
-          Sequel.pg_json(value)
-        else
-          value
-        end
+                          value.iso8601(6)
+                        elsif Hash === value
+                          Sequel.pg_json(value)
+                        else
+                          value
+                        end
         @pg_connection.literal(wrapped_value)
       end
 

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -99,7 +99,7 @@ module EventSourcery
         SQL
       end
 
-      def sql_literal_array(events, type, &block)
+      def sql_literal_array(events, type)
         sql_array = events.map do |event|
           to_sql_literal(yield event)
         end.join(', ')

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -36,9 +36,7 @@ module EventSourcery
                 order(:id).
                 where(Sequel.lit('id >= ?', id)).
                 limit(limit)
-        if event_types
-          query = query.where(type: event_types)
-        end
+        query = query.where(type: event_types) if event_types
         query.map { |event_row| build_event(event_row) }
       end
 

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -33,9 +33,9 @@ module EventSourcery
 
       def get_next_from(id, event_types: nil, limit: 1000)
         query = events_table.
-          order(:id).
-          where(Sequel.lit('id >= ?', id)).
-          limit(limit)
+                order(:id).
+                where(Sequel.lit('id >= ?', id)).
+                limit(limit)
         if event_types
           query = query.where(type: event_types)
         end
@@ -70,9 +70,7 @@ module EventSourcery
           subscription_master: subscription_master,
           on_new_events: block
         }
-        EventSourcery::EventStore::Subscription.new(args).tap do |s|
-          s.start
-        end
+        EventSourcery::EventStore::Subscription.new(args).tap(&:start)
       end
 
       private

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -39,9 +39,7 @@ module EventSourcery
         if event_types
           query = query.where(type: event_types)
         end
-        query.map do |event_row|
-          build_event(event_row)
-        end
+        query.map { |event_row| build_event(event_row) }
       end
 
       def latest_event_id(event_types: nil)

--- a/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
+++ b/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
@@ -4,7 +4,7 @@ module EventSourcery
     class OptimisedEventPollWaiter
       ListenThreadDied = Class.new(StandardError)
 
-      def initialize(pg_connection:, timeout: 30, after_listen: proc { })
+      def initialize(pg_connection:, timeout: 30, after_listen: proc {})
         @pg_connection = pg_connection
         @timeout = timeout
         @events_queue = QueueWithIntervalCallback.new
@@ -17,7 +17,7 @@ module EventSourcery
           block.call
         end
         start_async(after_listen: after_listen)
-        catch(:stop) {
+        catch(:stop) do
           block.call
           loop do
             ensure_listen_thread_alive!
@@ -25,7 +25,7 @@ module EventSourcery
             clear_new_event_queue
             block.call
           end
-        }
+        end
       ensure
         shutdown!
       end
@@ -54,10 +54,10 @@ module EventSourcery
 
       def start_async(after_listen: nil)
         after_listen_callback = if after_listen
-                                  proc {
+                                  proc do
                                     after_listen.call
                                     @after_listen.call if @after_listen
-                                  }
+                                  end
                                 else
                                   @after_listen
                                 end

--- a/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
+++ b/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
@@ -14,7 +14,7 @@ module EventSourcery
       def poll(after_listen: proc { }, &block)
         @events_queue.callback = proc do
           ensure_listen_thread_alive!
-          block.call
+          yield
         end
         start_async(after_listen: after_listen)
         catch(:stop) do

--- a/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
+++ b/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
@@ -57,9 +57,11 @@ module EventSourcery
                                 else
                                   @after_listen
                                 end
-        @listen_thread = Thread.new { listen_for_new_events(loop: true,
-                                                            after_listen: after_listen_callback,
-                                                            timeout: @timeout) }
+        @listen_thread = Thread.new do
+          listen_for_new_events(loop: true,
+                                after_listen: after_listen_callback,
+                                timeout: @timeout)
+        end
       end
 
       def listen_for_new_events(loop: true, after_listen: nil, timeout: 30)
@@ -67,9 +69,7 @@ module EventSourcery
                               loop: loop,
                               after_listen: after_listen,
                               timeout: timeout) do |_channel, _pid, _payload|
-          if @events_queue.empty?
-            @events_queue.push(:new_event_arrived)
-          end
+          @events_queue.push(:new_event_arrived) if @events_queue.empty?
         end
       end
     end

--- a/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
+++ b/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
@@ -33,15 +33,11 @@ module EventSourcery
       private
 
       def shutdown!
-        if @listen_thread.alive?
-          @listen_thread.kill
-        end
+        @listen_thread.kill if @listen_thread.alive?
       end
 
       def ensure_listen_thread_alive!
-        if !@listen_thread.alive?
-          raise ListenThreadDied
-        end
+        raise ListenThreadDied unless @listen_thread.alive?
       end
 
       def wait_for_new_event_to_appear

--- a/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
+++ b/lib/event_sourcery/postgres/optimised_event_poll_waiter.rb
@@ -18,12 +18,12 @@ module EventSourcery
         end
         start_async(after_listen: after_listen)
         catch(:stop) do
-          block.call
+          yield
           loop do
             ensure_listen_thread_alive!
             wait_for_new_event_to_appear
             clear_new_event_queue
-            block.call
+            yield
           end
         end
       ensure

--- a/lib/event_sourcery/postgres/projector.rb
+++ b/lib/event_sourcery/postgres/projector.rb
@@ -6,12 +6,12 @@ module EventSourcery
         base.prepend(TableOwner)
         base.include(InstanceMethods)
         base.class_eval do
-          alias project process
+          alias_method :project, :process
 
           class << self
-            alias project process
-            alias projects_events processes_events
-            alias projector_name processor_name
+            alias_method :project, :process
+            alias_method :projects_events, :processes_events
+            alias_method :projector_name, :processor_name
           end
         end
       end

--- a/lib/event_sourcery/postgres/queue_with_interval_callback.rb
+++ b/lib/event_sourcery/postgres/queue_with_interval_callback.rb
@@ -3,7 +3,7 @@ module EventSourcery
     class QueueWithIntervalCallback < ::Queue
       attr_accessor :callback
 
-      def initialize(callback: proc { }, callback_interval: EventSourcery::Postgres.config.callback_interval_if_no_new_events, poll_interval: 0.1)
+      def initialize(callback: proc {}, callback_interval: EventSourcery::Postgres.config.callback_interval_if_no_new_events, poll_interval: 0.1)
         @callback = callback
         @callback_interval = callback_interval
         @poll_interval = poll_interval
@@ -20,7 +20,7 @@ module EventSourcery
       def pop_with_interval_callback
         time = Time.now
         loop do
-          return pop(true) if !empty?
+          return pop(true) unless empty?
           if @callback_interval && Time.now > time + @callback_interval
             @callback.call
             time = Time.now

--- a/lib/event_sourcery/postgres/reactor.rb
+++ b/lib/event_sourcery/postgres/reactor.rb
@@ -58,7 +58,7 @@ module EventSourcery
                   Event.new(event_or_hash)
                 end
         raise UndeclaredEventEmissionError unless self.class.emits_event?(event.class)
-        event.body.merge!(DRIVEN_BY_EVENT_PAYLOAD_KEY => _event.id)
+        event.body[DRIVEN_BY_EVENT_PAYLOAD_KEY] = _event.id
         invoke_action_and_emit_event(event, block)
         EventSourcery.logger.debug { "[#{self.processor_name}] Emitted event: #{event.inspect}" }
       end

--- a/lib/event_sourcery/postgres/reactor.rb
+++ b/lib/event_sourcery/postgres/reactor.rb
@@ -53,10 +53,10 @@ module EventSourcery
 
       def emit_event(event_or_hash, &block)
         event = if Event === event_or_hash
-          event_or_hash
-        else
-          Event.new(event_or_hash)
-        end
+                  event_or_hash
+                else
+                  Event.new(event_or_hash)
+                end
         raise UndeclaredEventEmissionError unless self.class.emits_event?(event.class)
         event.body.merge!(DRIVEN_BY_EVENT_PAYLOAD_KEY => _event.id)
         invoke_action_and_emit_event(event, block)

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -1,7 +1,7 @@
 module EventSourcery
   module Postgres
     module Schema
-      extend self
+      module_function
 
       def create_event_store(db: EventSourcery::Postgres.config.event_store_database,
                              events_table_name: EventSourcery::Postgres.config.events_table_name,

--- a/lib/event_sourcery/postgres/table_owner.rb
+++ b/lib/event_sourcery/postgres/table_owner.rb
@@ -67,7 +67,7 @@ module EventSourcery
       end
 
       def table_name_prefixed(name)
-        [table_prefix, name].compact.join("_").to_sym
+        [table_prefix, name].compact.join('_').to_sym
       end
     end
   end

--- a/lib/event_sourcery/postgres/tracker.rb
+++ b/lib/event_sourcery/postgres/tracker.rb
@@ -44,9 +44,7 @@ module EventSourcery
 
       def last_processed_event_id(processor_name)
         track_entry = table.where(name: processor_name.to_s).first
-        if track_entry
-          track_entry[:last_processed_event_id]
-        end
+        track_entry[:last_processed_event_id] if track_entry
       end
 
       def tracked_processors

--- a/lib/event_sourcery/postgres/tracker.rb
+++ b/lib/event_sourcery/postgres/tracker.rb
@@ -13,7 +13,7 @@ module EventSourcery
         create_table_if_not_exists if EventSourcery::Postgres.config.auto_create_projector_tracker
 
         unless tracker_table_exists?
-          raise UnableToLockProcessorError, "Projector tracker table does not exist"
+          raise UnableToLockProcessorError, 'Projector tracker table does not exist'
         end
 
         if processor_name

--- a/lib/event_sourcery/postgres/tracker.rb
+++ b/lib/event_sourcery/postgres/tracker.rb
@@ -27,7 +27,7 @@ module EventSourcery
       def processed_event(processor_name, event_id)
         table.
           where(name: processor_name.to_s).
-                update(last_processed_event_id: event_id)
+          update(last_processed_event_id: event_id)
         true
       end
 

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = '0.2.0'
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = "0.2.0"
+    VERSION = '0.2.0'
   end
 end

--- a/script/bench_reading_events.rb
+++ b/script/bench_reading_events.rb
@@ -47,9 +47,7 @@ NUM_EVENTS = 10_000
 puts "Creating #{NUM_EVENTS} events"
 time = Benchmark.realtime do
   uuid = SecureRandom.uuid
-  NUM_EVENTS.times do
-    event_store.sink(new_event(uuid))
-  end
+  NUM_EVENTS.times { event_store.sink(new_event(uuid)) }
 end
 puts "Took #{time} to create events"
 

--- a/script/bench_reading_events.rb
+++ b/script/bench_reading_events.rb
@@ -29,11 +29,11 @@ end
 
 event_store = EventSourcery::Postgres.config.event_store
 
-EVENT_TYPES = %i[
+EVENT_TYPES = %i(
   item_added
   item_removed
   item_starred
-]
+).freeze
 
 def new_event(uuid)
   EventSourcery::Event.new(type: EVENT_TYPES.sample,

--- a/script/bench_writing_events.rb
+++ b/script/bench_writing_events.rb
@@ -41,7 +41,7 @@ def new_event
 end
 
 Benchmark.ips do |b|
-  b.report("event_store.sink") do
+  b.report('event_store.sink') do
     event_store.sink(new_event)
   end
 end

--- a/script/demonstrate_event_sequence_id_gaps.rb
+++ b/script/demonstrate_event_sequence_id_gaps.rb
@@ -132,7 +132,7 @@ stop = false
 Signal.trap(:INT) { stop = true }
 
 def wait_for_missing_ids(db, first_sequence, last_sequence, attempt: 1)
-  missing_ids = db[:events].where(Sequel.lit("id > ? AND id < ?", first_sequence, last_sequence)).order(:id).map {|e| e[:id] }
+  missing_ids = db[:events].where(Sequel.lit('id > ? AND id < ?', first_sequence, last_sequence)).order(:id).map {|e| e[:id] }
   expected_missing_ids = (first_sequence+1)..(last_sequence-1)
   if missing_ids == expected_missing_ids.to_a
     print "Missing events showed up after #{attempt} subsequent query. IDs: #{missing_ids}"
@@ -168,12 +168,12 @@ end
 Process.waitall
 
 puts
-puts "Looking for gaps in sequence IDs in events table:"
+puts 'Looking for gaps in sequence IDs in events table:'
 ids = db[:events].select(:id).order(:id).all.map { |e| e[:id] }
 expected_ids = (ids.min..ids.max).to_a
 missing_ids = (expected_ids - ids)
 if missing_ids.empty?
-  puts "No remaining gaps"
+  puts 'No remaining gaps'
 else
   missing_ids.each do |id|
     puts "Unable to find row with sequence ID #{id}"

--- a/script/demonstrate_event_sequence_id_gaps.rb
+++ b/script/demonstrate_event_sequence_id_gaps.rb
@@ -122,9 +122,7 @@ NUM_WRITER_PROCESSES.times do
     # inserts and no gaps are detected
     event_store = EventSourcery::Postgres::EventStore.new(db, lock_table: false)
     puts "#{Process.pid}: starting to write events"
-    until stop
-      event_store.sink(new_event)
-    end
+    event_store.sink(new_event) until stop
   end
 end
 

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe EventSourcery::Postgres::EventStore do
 
     def aggregate_version
       result = connection[:aggregates].
-        where(aggregate_id: aggregate_id).
-        first
+               where(aggregate_id: aggregate_id).
+               first
       if result
         result[:version]
       end

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -71,9 +71,7 @@ RSpec.describe EventSourcery::Postgres::EventStore do
     end
 
     context 'when the aggregate exists' do
-      before do
-        add_event
-      end
+      before { add_event }
 
       context 'with a correct expected version - 1' do
         it 'saves the event with and sets the aggregate version to version 2' do

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe EventSourcery::Postgres::EventStore do
       result = connection[:aggregates].
                where(aggregate_id: aggregate_id).
                first
-      if result
-        result[:version]
-      end
+      result[:version] if result
     end
 
     context "when the aggregate doesn't exist" do

--- a/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
+++ b/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
-  let(:after_listen) { proc { } }
+  let(:after_listen) { proc {} }
   subject(:waiter) { described_class.new(pg_connection: pg_connection, after_listen: after_listen) }
 
   before do
@@ -14,7 +14,7 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
   end
 
   it 'does an initial call' do
-    waiter.poll(after_listen: proc { }) do
+    waiter.poll(after_listen: proc {}) do
       @called = true
       throw :stop
     end
@@ -47,7 +47,7 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
 
     it 'raise an error' do
       expect {
-        waiter.poll { }
+        waiter.poll {}
       }.to raise_error(described_class::ListenThreadDied)
     end
   end

--- a/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
+++ b/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
     end
   end
 
-  context "when an error is raised" do
+  context 'when an error is raised' do
     let(:thread) { double }
 
     before { allow(Thread).to receive(:new).and_return(thread) }
 
-    context "when the listening thread is alive" do
-      it "kills the listening thread" do
+    context 'when the listening thread is alive' do
+      it 'kills the listening thread' do
         allow(thread).to receive(:alive?).and_return(true)
         expect(thread).to receive(:kill)
 
@@ -69,8 +69,8 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
       end
     end
 
-    context "when the listening thread is not alive" do
-      it "does not try to kill any listening threads" do
+    context 'when the listening thread is not alive' do
+      it 'does not try to kill any listening threads' do
         allow(thread).to receive(:alive?).and_return(false)
         expect(thread).to_not receive(:kill)
 

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
   describe '#project' do
     let(:event) { new_event(type: :terms_accepted) }
 
-    it "processes events via project method" do
+    it 'processes events via project method' do
       projector = new_projector do
         def project(event)
           @processed_event = event
@@ -170,7 +170,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
 
     context 'when an error occurs processing the event' do
 
-      it "rolls back the projected changes" do
+      it 'rolls back the projected changes' do
         projector.raise_error = true
         projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil
         expect(connection[:profiles].count).to eq 0
@@ -183,7 +183,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
         allow(tracker).to receive(:processed_event).and_raise(StandardError)
       end
 
-      it "rolls back the projected changes" do
+      it 'rolls back the projected changes' do
         projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil
         expect(connection[:profiles].count).to eq 0
       end

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe EventSourcery::Postgres::Projector do
-  let(:projector_class) {
+  let(:projector_class) do
     Class.new do
       include EventSourcery::Postgres::Projector
       processor_name 'test_processor'
@@ -19,7 +19,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
 
       attr_reader :processed_event
     end
-  }
+  end
   let(:projector_name) { 'my_projector' }
   let(:tracker) { EventSourcery::Postgres::Tracker.new(pg_connection) }
   let(:events) { [] }
@@ -40,12 +40,12 @@ RSpec.describe EventSourcery::Postgres::Projector do
     end.new(tracker: tracker, db_connection: pg_connection)
   end
 
-  subject(:projector) {
+  subject(:projector) do
     projector_class.new(
       tracker: tracker,
       db_connection: connection
     )
-  }
+  end
   let(:aggregate_id) { SecureRandom.uuid }
 
   after { release_advisory_locks }
@@ -136,7 +136,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
     let(:event_store) { double(:event_store) }
     let(:events) { [new_event(id: 1), new_event(id: 2)] }
     let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
-    let(:projector_class) {
+    let(:projector_class) do
       Class.new do
         include EventSourcery::Postgres::Projector
         processor_name 'test_processor'
@@ -156,7 +156,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
           raise 'boo' if raise_error
         end
       end
-    }
+    end
 
     before do
       allow(event_store).to receive(:subscribe).and_yield(events).once

--- a/spec/event_sourcery/postgres/reactor_spec.rb
+++ b/spec/event_sourcery/postgres/reactor_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
       before do
         reactor.setup
-        stub_const("TestActioner", action_stub_class)
+        stub_const('TestActioner', action_stub_class)
       end
 
       def event_count
@@ -263,12 +263,12 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
         it 'can manupulate the event body as part of the action' do
           reactor.process(event_1)
-          expect(latest_events(1).first.body["token"]).to eq 'secret-identifier'
+          expect(latest_events(1).first.body['token']).to eq 'secret-identifier'
         end
 
         it 'stores the driven by event id in the body' do
           reactor.process(event_1)
-          expect(latest_events(1).first.body["_driven_by_event_id"]).to eq event_1.id
+          expect(latest_events(1).first.body['_driven_by_event_id']).to eq event_1.id
         end
       end
     end

--- a/spec/event_sourcery/postgres/reactor_spec.rb
+++ b/spec/event_sourcery/postgres/reactor_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
   ItemViewed = Class.new(EventSourcery::Event)
   EchoEvent = Class.new(EventSourcery::Event)
 
-  let(:reactor_class) {
+  let(:reactor_class) do
     Class.new do
       include EventSourcery::Postgres::Reactor
 
@@ -15,8 +15,8 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
       attr_reader :processed_event
     end
-  }
-  let(:reactor_class_with_emit) {
+  end
+  let(:reactor_class_with_emit) do
     Class.new do
       include EventSourcery::Postgres::Reactor
 
@@ -26,7 +26,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
       def process(event)
       end
     end
-  }
+  end
 
   let(:tracker) { EventSourcery::EventProcessing::EventTrackers::Memory.new }
   let(:reactor_name) { 'my_reactor' }
@@ -159,7 +159,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
       let(:event_5) { TermsAccepted.new(id: 5, aggregate_id: aggregate_id, body: { time: Time.now }) }
       let(:event_6) { EchoEvent.new(id: 6, aggregate_id: aggregate_id, body: event_3.body.merge(EventSourcery::Postgres::Reactor::DRIVEN_BY_EVENT_PAYLOAD_KEY => 3)) }
       let(:events) { [event_1, event_2, event_3, event_4] }
-      let(:action_stub_class) {
+      let(:action_stub_class) do
         Class.new do
           def self.action(id)
             actioned << id
@@ -169,8 +169,8 @@ RSpec.describe EventSourcery::Postgres::Reactor do
             @actions ||= []
           end
         end
-      }
-      let(:reactor_class) {
+      end
+      let(:reactor_class) do
         Class.new do
           include EventSourcery::Postgres::Reactor
 
@@ -186,7 +186,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
           attr_reader :event
         end
-      }
+      end
 
       before do
         reactor.setup
@@ -202,7 +202,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
       end
 
       context "when the event emitted doesn't take actions" do
-        let(:reactor_class) {
+        let(:reactor_class) do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
@@ -213,7 +213,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
               emit_event(EchoEvent.new(aggregate_id: event.aggregate_id, body: event.body))
             end
           end
-        }
+        end
 
         it 'processes the events as usual' do
           [event_1, event_2, event_3, event_4, event_5].each do |event|
@@ -224,7 +224,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
       end
 
       context "when the event emitted hasn't been defined in emit_events" do
-        let(:reactor_class) {
+        let(:reactor_class) do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
@@ -235,7 +235,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
               emit_event(ItemViewed.new(aggregate_id: event.aggregate_id, body: event.body))
             end
           end
-        }
+        end
 
         it 'raises an error' do
           expect {
@@ -246,7 +246,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
       context 'when body is yielded to the emit block' do
         let(:events) { [] }
-        let(:reactor_class) {
+        let(:reactor_class) do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
@@ -259,7 +259,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
               end
             end
           end
-        }
+        end
 
         it 'can manupulate the event body as part of the action' do
           reactor.process(event_1)

--- a/spec/event_sourcery/postgres/tracker_spec.rb
+++ b/spec/event_sourcery/postgres/tracker_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe EventSourcery::Postgres::Tracker do
   end
 
   describe '#processed_event' do
-    before do
-      setup_table
-    end
+    before { setup_table }
 
     it 'updates the tracker entry to the given ID' do
       postgres_tracker.processed_event(processor_name, 1)
@@ -63,7 +61,6 @@ RSpec.describe EventSourcery::Postgres::Tracker do
     context 'when the block succeeds' do
       it 'marks the event as processed' do
         postgres_tracker.processing_event(processor_name, 1) do
-
         end
         expect(last_processed_event_id).to eq 1
       end
@@ -72,11 +69,11 @@ RSpec.describe EventSourcery::Postgres::Tracker do
     context 'when the block raises' do
       it "doesn't mark the event as processed and raises an error" do
         expect(last_processed_event_id).to eq 0
-        expect {
+        expect do
           postgres_tracker.processing_event(processor_name, 1) do
             raise 'boo'
           end
-        }.to raise_error(RuntimeError)
+        end.to raise_error(RuntimeError)
         expect(last_processed_event_id).to eq 0
       end
     end
@@ -85,31 +82,27 @@ RSpec.describe EventSourcery::Postgres::Tracker do
       let(:db) { new_connection }
 
       it 'raises an error' do
-        expect {
+        expect do
           tracker = described_class.new(db, table_name: table_name)
           tracker.setup(processor_name)
-        }.to raise_error(EventSourcery::UnableToLockProcessorError)
+        end.to raise_error(EventSourcery::UnableToLockProcessorError)
       end
 
       context 'with obtain_processor_lock: false' do
         it "doesn't raises an error" do
-          expect {
+          expect do
             tracker = described_class.new(db, table_name: table_name, obtain_processor_lock: false)
             tracker.setup(processor_name)
-          }.to_not raise_error
+          end.to_not raise_error
         end
       end
 
-      after do
-        release_advisory_locks(db)
-      end
+      after { release_advisory_locks(db) }
     end
   end
 
   describe '#last_processed_event_id' do
-    before do
-      setup_table
-    end
+    before { setup_table }
 
     it 'starts at 0' do
       expect(last_processed_event_id).to eq 0
@@ -122,9 +115,7 @@ RSpec.describe EventSourcery::Postgres::Tracker do
   end
 
   describe '#reset_last_processed_event_id' do
-    before do
-      setup_table
-    end
+    before { setup_table }
 
     it 'resets the last processed event back to 0' do
       postgres_tracker.processed_event(processor_name, 1)

--- a/spec/event_sourcery/postgres/tracker_spec.rb
+++ b/spec/event_sourcery/postgres/tracker_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe EventSourcery::Postgres::Tracker do
     context 'unable to lock tracker row' do
       let(:db) { new_connection }
 
-      it "raises an error" do
+      it 'raises an error' do
         expect {
           tracker = described_class.new(db, table_name: table_name)
           tracker.setup(processor_name)

--- a/spec/event_sourcery/postgres_spec.rb
+++ b/spec/event_sourcery/postgres_spec.rb
@@ -1,7 +1,7 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe EventSourcery::Postgres do
-  it "has a version number" do
+  it 'has a version number' do
     expect(EventSourcery::Postgres::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "bundler/setup"
-require "event_sourcery/postgres"
+require 'bundler/setup'
+require 'event_sourcery/postgres'
 require 'event_sourcery/rspec/event_store_shared_examples'
 require 'timeout'
 
@@ -7,7 +7,7 @@ Dir.glob(File.dirname(__FILE__) + '/support/**/*.rb') { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -28,7 +28,7 @@ module DBHelpers
 
   def reset_database
     connection.execute('truncate table aggregates')
-    %w(events events_without_optimistic_locking).each do |table|
+    %w(events events_without_optimistic_locking).each do |_|
       connection.execute('truncate table events')
       connection.execute('alter sequence events_id_seq restart with 1')
     end

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -28,7 +28,7 @@ module DBHelpers
 
   def reset_database
     connection.execute('truncate table aggregates')
-    %w[ events events_without_optimistic_locking ].each do |table|
+    %w(events events_without_optimistic_locking).each do |table|
       connection.execute('truncate table events')
       connection.execute('alter sequence events_id_seq restart with 1')
     end

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -37,15 +37,15 @@ module DBHelpers
   end
 
   def recreate_database
-    pg_connection.execute("drop table if exists events")
-    pg_connection.execute("drop table if exists aggregates")
-    pg_connection.execute("drop table if exists projector_tracker")
+    pg_connection.execute('drop table if exists events')
+    pg_connection.execute('drop table if exists aggregates')
+    pg_connection.execute('drop table if exists projector_tracker')
     EventSourcery::Postgres::Schema.create_event_store(db: pg_connection)
     EventSourcery::Postgres::Schema.create_projector_tracker(db: pg_connection)
   end
 
   def release_advisory_locks(connection=pg_connection)
-    connection.fetch("SELECT pg_advisory_unlock_all();").to_a
+    connection.fetch('SELECT pg_advisory_unlock_all();').to_a
   end
 end
 

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -22,9 +22,7 @@ module DBHelpers
     if ENV['BUILDKITE']
       'postgres://buildkite-agent:127.0.0.1:5432/'
     else
-      ENV.fetch('BOXEN_POSTGRESQL_URL') {
-        'postgres://127.0.0.1:5432/'
-      }
+      ENV.fetch('BOXEN_POSTGRESQL_URL') { 'postgres://127.0.0.1:5432/' }
     end
   end
 


### PR DESCRIPTION
Just a series of minor tweaks to ze code.

Things included;
whitespace removals
inlining some 1 line blocks
using `alias_method` instead of `alias`
using `module_function` instead of `extend self`
changing double quoties to single quoteis when not needed
removing an unused arg from a method https://github.com/envato/event_sourcery-postgres/commit/4e1949a5bc9846f2048d0e640dfc761100747040
changing `block.call` to `yield`
I think thats the majority of what this is..

Feel free to nitpick my nitpicks 
💞 
