### PR TITLE
Convert aggregate id to string

### DIFF
--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -57,8 +57,8 @@ module EventSourcery
         end
       end
 
-      def get_events_for_aggregate_id(id)
-        events_table.where(aggregate_id: id).order(:version).map do |event_hash|
+      def get_events_for_aggregate_id(aggregate_id)
+        events_table.where(aggregate_id: aggregate_id.to_str).order(:version).map do |event_hash|
           build_event(event_hash)
         end
       end

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -97,7 +97,7 @@ module EventSourcery
         causation_ids = sql_literal_array(events, 'uuid', &:causation_id)
         <<-SQL
           select #{@write_events_function_name}(
-            #{sql_literal(aggregate_id, 'uuid')},
+            #{sql_literal(aggregate_id.to_str, 'uuid')},
             #{types},
             #{sql_literal(expected_version, 'int')},
             #{bodies},

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe EventSourcery::Postgres::EventStore do
   describe '#get_events_for_aggregate_id' do
     RSpec.shared_examples 'gets events for a specific aggregate id' do
       before do
-        event_store.sink(new_event(aggregate_id: aggregate_id, type: 'item_added'))
-        event_store.sink(new_event(aggregate_id: aggregate_id, type: 'item_updated'))
+        event_store.sink(new_event(aggregate_id: aggregate_id, type: 'event_with_a_string_id'))
+        event_store.sink(new_event(aggregate_id: double(to_str: aggregate_id), type: 'event_with_a_stringifiable_id'))
         event_store.sink(new_event(aggregate_id: SecureRandom.uuid, type: 'i_should_not_be_loaded'))
       end
 
       subject(:events) { event_store.get_events_for_aggregate_id(uuid) }
 
       specify do
-        expect(events.map(&:type)).to eq(['item_added', 'item_updated'])
+        expect(events.map(&:type)).to eq(['event_with_a_string_id', 'event_with_a_stringifiable_id'])
       end
     end
 


### PR DESCRIPTION
This PR adds support for using any class that can be converted to string with `.to_str`  as `aggregate_id` when loading and persisting events.

In one of our apps we are using `UUIDTools::UUID` as aggregate ids. We have to explicitly convert such ids to strings in our code to pass them to `EventStore` to load aggregate events because Sequel cannot implicitly convert them to strings.