### PR TITLE
Postgres event store persists correlation_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- The event store persists the event `causation_id`. To facilitate this
-  a `causation_id` column has been added to the `events` table and the
-  `write_events` function has been altered. Event Sourcery apps will need
-  to ensure these DB changes have been applied to use this version of
-  Event Sourcery.
+- The event store persists the event `correlation_id` and `causation_id`.
+  To facilitate this `correlation_id` and `causation_id` columns have been
+  added to the `events` table and the `write_events` function has been
+  altered. Event Sourcery apps will need to ensure these DB changes have
+  been applied to use this version of Event Sourcery.
 
 ## [0.2.0] - 2017-6-1
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ ruby '>= 2.2.0'
 
 gemspec
 
-gem 'event_sourcery', git: 'https://github.com/envato/event_sourcery.git'
+gem 'event_sourcery', git: 'https://github.com/envato/event_sourcery.git', branch: 'event_with'

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -94,6 +94,7 @@ module EventSourcery
         types = sql_literal_array(events, 'varchar', &:type)
         created_ats = sql_literal_array(events, 'timestamp without time zone', &:created_at)
         event_uuids = sql_literal_array(events, 'uuid', &:uuid)
+        correlation_ids = sql_literal_array(events, 'uuid', &:correlation_id)
         causation_ids = sql_literal_array(events, 'uuid', &:causation_id)
         <<-SQL
           select #{@write_events_function_name}(
@@ -103,6 +104,7 @@ module EventSourcery
             #{bodies},
             #{created_ats},
             #{event_uuids},
+            #{correlation_ids},
             #{causation_ids},
             #{sql_literal(@lock_table, 'boolean')}
           );


### PR DESCRIPTION
### Context

In https://github.com/envato/event_sourcery/pull/125 we added a `correlation_id` attribute to the `Event` class. Then in https://github.com/envato/event_sourcery/pull/160 we added the expectation that all Event Sourcery event stores will persist this value.

### Change

Similar to #18: update the PostgreSQL event store so that it persists the `correlation_id` event attribute. This includes adding a column to the `events` table and updating the `write_events` function to populate it.

### Considerations

We'll need to ensure that all Event Sourcery applications make this schema change when upgrading to the next version of Event Sourcery.

Although there are no specs added here. There are some covering this change in the event store shared RSpec examples provided by the `event_sourcery` gem. The build will be broken till this change is applied.
