### PR TITLE
Remove processes_events and projects_events in favour of process and project class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Only send info log after processing a group of events
 
+### Removed
+  - Remove `processes_events` and `projects_events` as these have been [removed
+  in event_sourcery](https://github.com/envato/event_sourcery/pull/161).
+
 ## [0.5.0] - 2017-7-27
 - First Version of YARD documentation.
 - Fix Sequel deprecation by globally loading pg extensions

--- a/lib/event_sourcery/postgres/projector.rb
+++ b/lib/event_sourcery/postgres/projector.rb
@@ -10,7 +10,6 @@ module EventSourcery
 
           class << self
             alias_method :project, :process
-            alias_method :projects_events, :processes_events
             alias_method :projector_name, :processor_name
           end
         end

--- a/spec/event_sourcery/postgres/reactor_spec.rb
+++ b/spec/event_sourcery/postgres/reactor_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
     Class.new do
       include EventSourcery::Postgres::Reactor
 
-      processes_events :terms_accepted
-
-      def process(event)
+      process TermsAccepted do |event|
         @processed_event = event
       end
 
@@ -20,10 +18,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
     Class.new do
       include EventSourcery::Postgres::Reactor
 
-      processes_events :terms_accepted
       emits_events TermsConfirmationEmailSent
 
-      def process(event)
+      process TermsAccepted do |event|
       end
     end
   end
@@ -112,7 +109,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
   describe '#reset' do
     it 'resets last processed event ID' do
-      reactor.process(OpenStruct.new(type: :terms_accepted, id: 1))
+      reactor.process(TermsAccepted.new(id: 1))
       reactor.reset
       expect(tracker.last_processed_event_id(:test_processor)).to eq 0
     end
@@ -145,7 +142,7 @@ RSpec.describe EventSourcery::Postgres::Reactor do
   end
 
   describe '#process' do
-    let(:event) { OpenStruct.new(type: :terms_accepted, id: 1) }
+    let(:event) { TermsAccepted.new(id: 1) }
 
     it "projects events it's interested in" do
       reactor.process(event)
@@ -190,10 +187,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
         Class.new do
           include EventSourcery::Postgres::Reactor
 
-          processes_events :terms_accepted
           emits_events EchoEvent
 
-          def process(event)
+          process TermsAccepted do |event|
             @event = event
             emit_event(EchoEvent.new(aggregate_id: event.aggregate_id, body: event.body)) do
               TestActioner.action(event.id)
@@ -222,10 +218,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
-            processes_events :terms_accepted
             emits_events EchoEvent
 
-            def process(event)
+            process TermsAccepted do |event|
               emit_event(EchoEvent.new(aggregate_id: event.aggregate_id, body: event.body))
             end
           end
@@ -254,10 +249,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
-            processes_events :terms_accepted
             emits_events EchoEvent
 
-            def process(event)
+            process TermsAccepted do |event|
               emit_event(ItemViewed.new(aggregate_id: event.aggregate_id, body: event.body))
             end
           end
@@ -276,10 +270,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
           Class.new do
             include EventSourcery::Postgres::Reactor
 
-            processes_events :terms_accepted
             emits_events EchoEvent
 
-            def process(event)
+            process TermsAccepted do |event|
               emit_event(EchoEvent.new(aggregate_id: event.aggregate_id)) do |body|
                 body[:token] = 'secret-identifier'
               end


### PR DESCRIPTION
`processes_events` is being removed from `event_sourcery` https://github.com/envato/event_sourcery/pull/161.