### PR TITLE
Bump version and stop blocking pushes to rubygems.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.3.0] - 2017-6-16
 ### Changed
 - The event store persists the event `correlation_id` and `causation_id`.
   To facilitate this `correlation_id` and `causation_id` columns have been

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@ source 'https://rubygems.org'
 ruby '>= 2.2.0'
 
 gemspec
-
-gem 'event_sourcery', git: 'https://github.com/envato/event_sourcery.git'

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -13,15 +13,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Postgres event store for use with EventSourcery}
   spec.homepage      = "https://github.com/envato/event_sourcery-postgres"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
- Allow pushing to rubygems.org
- Bump version to 0.3.0
- No longer need to source `event_sourcery` from GitHub