### PR TITLE
Reactors Populate Event Causation Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   added to the `events` table and the `write_events` function has been
   altered. Event Sourcery apps will need to ensure these DB changes have
   been applied to use this version of Event Sourcery.
+- Reactors store the UUID of the event being processed in the `causation_id`
+  of any emitted events. This replaces the old behaviour of storing id of the
+  event being processed in a `_driven_by_event_id` attribute in the emitted
+  event's body.
 
 ## [0.2.0] - 2017-6-1
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 ruby '>= 2.2.0'
 
 gemspec
+
+ gem 'event_sourcery', git: 'https://github.com/envato/event_sourcery.git'

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sequel', '~> 4.38'
   spec.add_dependency 'pg'
-  spec.add_dependency 'event_sourcery', '>= 0.10.0'
+  spec.add_dependency 'event_sourcery', '>= 0.14.0'
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/event_sourcery/postgres/reactor.rb
+++ b/lib/event_sourcery/postgres/reactor.rb
@@ -45,8 +45,6 @@ module EventSourcery
         end
       end
 
-      DRIVEN_BY_EVENT_PAYLOAD_KEY = :_driven_by_event_id
-
       private
 
       attr_reader :event_sink, :event_source
@@ -58,7 +56,7 @@ module EventSourcery
           Event.new(event_or_hash)
         end
         raise UndeclaredEventEmissionError unless self.class.emits_event?(event.class)
-        event.body.merge!(DRIVEN_BY_EVENT_PAYLOAD_KEY => _event.id)
+        event = event.with(causation_id: _event.uuid)
         invoke_action_and_emit_event(event, block)
         EventSourcery.logger.debug { "[#{self.processor_name}] Emitted event: #{event.inspect}" }
       end

--- a/spec/event_sourcery/postgres/reactor_spec.rb
+++ b/spec/event_sourcery/postgres/reactor_spec.rb
@@ -153,11 +153,11 @@ RSpec.describe EventSourcery::Postgres::Reactor do
 
     context 'with a reactor that emits events' do
       let(:event_1) { TermsAccepted.new(id: 1, aggregate_id: aggregate_id, body: { time: Time.now }) }
-      let(:event_2) { EchoEvent.new(id: 2, aggregate_id: aggregate_id, body: event_1.body.merge(EventSourcery::Postgres::Reactor::DRIVEN_BY_EVENT_PAYLOAD_KEY => 1)) }
+      let(:event_2) { EchoEvent.new(id: 2, aggregate_id: aggregate_id, body: event_1.body, causation_id: event_1.uuid) }
       let(:event_3) { TermsAccepted.new(id: 3, aggregate_id: aggregate_id, body: { time: Time.now }) }
       let(:event_4) { TermsAccepted.new(id: 4, aggregate_id: aggregate_id, body: { time: Time.now }) }
       let(:event_5) { TermsAccepted.new(id: 5, aggregate_id: aggregate_id, body: { time: Time.now }) }
-      let(:event_6) { EchoEvent.new(id: 6, aggregate_id: aggregate_id, body: event_3.body.merge(EventSourcery::Postgres::Reactor::DRIVEN_BY_EVENT_PAYLOAD_KEY => 3)) }
+      let(:event_6) { EchoEvent.new(id: 6, aggregate_id: aggregate_id, body: event_3.body, causation_id: event_3.uuid) }
       let(:events) { [event_1, event_2, event_3, event_4] }
       let(:action_stub_class) {
         Class.new do
@@ -266,9 +266,9 @@ RSpec.describe EventSourcery::Postgres::Reactor do
           expect(latest_events(1).first.body["token"]).to eq 'secret-identifier'
         end
 
-        it 'stores the driven by event id in the body' do
+        it 'stores the event causation id' do
           reactor.process(event_1)
-          expect(latest_events(1).first.body["_driven_by_event_id"]).to eq event_1.id
+          expect(latest_events(1).first.causation_id).to eq event_1.uuid
         end
       end
     end


### PR DESCRIPTION
When an event is emitted from a reactor we want to record which event we were processing at the time. This is a great aid to debugging.

Currently we record this fact by storing the event id of the event being processed in the emitted event's body with the attribute name `_driven_by_event_id`.

This PR proposes to change this to store the UUID of the event being processed in the `causation_id` attribute of the emitted event.