### PR TITLE
Reactor populates correlation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   event being processed in a `_driven_by_event_id` attribute in the emitted
   event's body.
 
+### Added
+- Reactors store the correlation id of the event being processed in the
+  `correlation_id` of any emitted events.
+
 ## [0.3.0] - 2017-6-16
 ### Changed
 - The event store persists the event `correlation_id` and `causation_id`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Reactors store the UUID of the event being processed in the `causation_id`
+  of any emitted events. This replaces the old behaviour of storing id of the
+  event being processed in a `_driven_by_event_id` attribute in the emitted
+  event's body.
 
 ## [0.3.0] - 2017-6-16
 ### Changed
@@ -13,10 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   added to the `events` table and the `write_events` function has been
   altered. Event Sourcery apps will need to ensure these DB changes have
   been applied to use this version of Event Sourcery.
-- Reactors store the UUID of the event being processed in the `causation_id`
-  of any emitted events. This replaces the old behaviour of storing id of the
-  event being processed in a `_driven_by_event_id` attribute in the emitted
-  event's body.
 
 ## [0.2.0] - 2017-6-1
 ### Changed

--- a/lib/event_sourcery/postgres/reactor.rb
+++ b/lib/event_sourcery/postgres/reactor.rb
@@ -56,7 +56,7 @@ module EventSourcery
                   Event.new(event_or_hash)
                 end
         raise UndeclaredEventEmissionError unless self.class.emits_event?(event.class)
-        event = event.with(causation_id: _event.uuid)
+        event = event.with(causation_id: _event.uuid, correlation_id: _event.correlation_id)
         invoke_action_and_emit_event(event, block)
         EventSourcery.logger.debug { "[#{self.processor_name}] Emitted event: #{event.inspect}" }
       end


### PR DESCRIPTION
When an event is emitted from a reactor we want its `correlation_id` to be the same as the `correlation_id`  of the event being processed.

Also move the `causation_id` changelog entry up to the unreleased section. It didn't make version 0.3. Bad merge added it at the wrong location.