### PR TITLE
Add indexes for `correlation_id` and `causation_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added index on the `events` table for `correlation_id` and `causation_id`
+  columns.
 
 ## [0.3.0] - 2017-6-16
 ### Changed

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -28,6 +28,8 @@ module EventSourcery
           index [:aggregate_id, :version], unique: true
           index :uuid, unique: true
           index :type
+          index :correlation_id
+          index :causation_id
           index :created_at
         end
       end


### PR DESCRIPTION
Add two indexes to the `events` table. One for `correlation_id` and one for `causation_id`.

I'm a little concerned with the number of indexes on this table now. Are there any we can remove? `created_at` perhaps.