### PR TITLE
[wip] Fix race condition when creating projector tracker table

### DIFF
--- a/lib/event_sourcery/postgres/tracker.rb
+++ b/lib/event_sourcery/postgres/tracker.rb
@@ -18,16 +18,12 @@ module EventSourcery
 
         if processor_name
           create_track_entry_if_not_exists(processor_name)
-          if @obtain_processor_lock
-            obtain_global_lock_on_processor(processor_name)
-          end
+          obtain_global_lock_on_processor(processor_name) if @obtain_processor_lock
         end
       end
 
       def processed_event(processor_name, event_id)
-        table.
-          where(name: processor_name.to_s).
-          update(last_processed_event_id: event_id)
+        table.where(name: processor_name.to_s).update(last_processed_event_id: event_id)
         true
       end
 
@@ -43,8 +39,9 @@ module EventSourcery
       end
 
       def last_processed_event_id(processor_name)
-        track_entry = table.where(name: processor_name.to_s).first
-        track_entry[:last_processed_event_id] if track_entry
+        if track_entry = table.where(name: processor_name.to_s).first
+          track_entry[:last_processed_event_id]
+        end
       end
 
       def tracked_processors
@@ -53,17 +50,38 @@ module EventSourcery
 
       private
 
+      def obtained_global_lock?(lock_id)
+        @connection.fetch("select pg_try_advisory_lock(#{lock_id})").to_a.first[:pg_try_advisory_lock]
+      end
+
+      def release_global_lock(lock_id)
+        @connection.execute("select pg_advisory_unlock(#{lock_id});")
+      end
+
       def obtain_global_lock_on_processor(processor_name)
-        lock_obtained = @connection.fetch("select pg_try_advisory_lock(#{@track_entry_id})").to_a.first[:pg_try_advisory_lock]
-        if lock_obtained == false
+        unless obtained_global_lock?(@track_entry_id)
           raise UnableToLockProcessorError, "Unable to get a lock on #{processor_name} #{@track_entry_id}"
         end
       end
 
+      def exclusive(lock_id=1, &block)
+        if obtained_global_lock?(lock_id)
+          begin
+            yield
+          ensure
+            release_global_lock(lock_id)
+          end
+        end
+      end
+
       def create_table_if_not_exists
-        unless tracker_table_exists?
-          EventSourcery.logger.info { "Projector tracker missing - attempting to create 'projector_tracker' table" }
-          EventSourcery::Postgres::Schema.create_projector_tracker(db: @connection, table_name: @table_name)
+        attempt = 1
+        while !tracker_table_exists? && attempt < 5 do
+          exclusive do
+            EventSourcery.logger.info { "Projector tracker missing - attempting to create '#{@table_name}' table" }
+            EventSourcery::Postgres::Schema.create_projector_tracker(db: @connection, table_name: @table_name)
+          end
+          attempt += 1
         end
       end
 

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe EventSourcery::Postgres::EventStore do
   end
 
   describe '#subscribe' do
+    let(:pg_connection) { new_connection }
     let(:event) { new_event(aggregate_id: aggregate_id) }
     let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
 


### PR DESCRIPTION
When running the [event_sourcery_todo_app](https://github.com/envato/event_sourcery_todo_app) for the very first time it will output a bunch of errors being caused by a race condition when attempting to create the projector tracker table.

The reason it occurs is because we have many ESP's which are all forked into separate processes during startup https://github.com/envato/event_sourcery_todo_app/blob/master/Rakefile#L18-L51 and each of the processes attempts to generate the projector tracker table asynchronously.

This PR attempts to avoid the race condition by wrapping the table generation within an advisory lock provided by Postgres.

Having to use any sort of global lock on Postgres is not ideal though, so I'm reaching out for feedback to see if anyone has any better alternatives? @stevehodgkiss @grassdog @orien