### PR TITLE
Coerce table name to a symbol

### DIFF
--- a/lib/event_sourcery/postgres/tracker.rb
+++ b/lib/event_sourcery/postgres/tracker.rb
@@ -5,7 +5,7 @@ module EventSourcery
                      table_name: EventSourcery::Postgres.config.tracker_table_name,
                      obtain_processor_lock: true)
         @connection = connection
-        @table_name = table_name
+        @table_name = table_name.to_sym
         @obtain_processor_lock = obtain_processor_lock
       end
 

--- a/spec/event_sourcery/postgres/tracker_spec.rb
+++ b/spec/event_sourcery/postgres/tracker_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe EventSourcery::Postgres::Tracker do
       end
     end
 
+    context 'when table_name is a string' do
+      let(:table_name) { 'tracker' }
+
+      it 'does not raise an error' do
+        expect { postgres_tracker.setup(processor_name) }.not_to raise_error
+      end
+
+      it 'creates the table' do
+        postgres_tracker.setup(processor_name)
+        expect(connection.table_exists?(table_name)).to be_truthy
+      end
+    end
+
     context 'auto create projector tracker disabled' do
       before do
         allow(EventSourcery::Postgres.config).to receive(:auto_create_projector_tracker).and_return(false)


### PR DESCRIPTION
Table name needs to be a symbol. Lets ensure it gets converted to a
symbol.

When you define the table_name as a string it gives the following error:

```
     Sequel::DatabaseError:
       PG::SyntaxError: ERROR:  syntax error at or near "tracker"
       LINE 1: tracker
               ^
     # ./lib/event_sourcery/postgres/tracker.rb:71:in `create_track_entry_if_not_exists'
     # ./lib/event_sourcery/postgres/tracker.rb:20:in `setup'
     # ./spec/event_sourcery/postgres/tracker_spec.rb:42:in `block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # PG::SyntaxError:
     #   ERROR:  syntax error at or near "tracker"
     #   LINE 1: tracker
     #           ^
     #   ./lib/event_sourcery/postgres/tracker.rb:71:in `create_track_entry_if_not_exists'
```