### PR TITLE
Preparation for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.4.0] - 2017-6-21
 ### Changed
 - Reactors store the UUID of the event being processed in the `causation_id`
   of any emitted events. This replaces the old behaviour of storing id of the

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/envato/event_sourcery-postgres'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(\.|bin/|Gemfile|Rakefile|script/|spec/)})
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -6,9 +6,9 @@ require 'event_sourcery/postgres/version'
 Gem::Specification.new do |spec|
   spec.name          = 'event_sourcery-postgres'
   spec.version       = EventSourcery::Postgres::VERSION
-  # TODO: update authors
-  spec.authors       = ['Steve Hodgkiss']
-  spec.email         = ['steve@hodgkiss.me']
+
+  spec.authors       = ['Envato']
+  spec.email         = ['rubygems@envato.com']
 
   spec.summary       = 'Postgres event store for use with EventSourcery'
   spec.homepage      = 'https://github.com/envato/event_sourcery-postgres'

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end


### PR DESCRIPTION
* Remove a few unrequired files from the gem package
* Set Envato as the author
* Bump version 0.3.0 -> 0.4.0
* Mark changes as released in changelog
