### PR TITLE
Support event schema validation

### DIFF
--- a/lib/event_sourcery/postgres/reactor.rb
+++ b/lib/event_sourcery/postgres/reactor.rb
@@ -74,7 +74,11 @@ module EventSourcery
 
       def invoke_action_and_emit_event(event, action)
         action.call(event.body) if action
-        event_sink.sink(event)
+        if event.valid?
+          event_sink.sink(event)
+        else
+          raise(EventSourcery::InvalidEventError, "#{event.class} not valid: #{event.validation_errors.values.join(', ')}")
+        end
       end
     end
   end


### PR DESCRIPTION
My team is working on an Event Sourcery app. We want to introduce event schema validation because:
- Event schemas document the intended structure of events and allow us to trace their history
- With a little bit of metaprogramming we can replace event body hash digging with attributes on events, making our code more readable
- Schema validation ensures all events have the intended format before being saved to the event store.
- Schema validation helps ensure that specs don't make faulty assumptions when creating test inputs. 

Other Envato apps have enforced validation of their event schemas by introducing parallel methods to `apply_event` and `emit_event` named `validate_and_apply_event` and `validate_and_emit_event`. I believe it would be better for schema validation to be directly supported by Event Sourcery rather than for each Event Sourcery app to implement it independently.

This PR adds that support. Note that event schema validation is entirely optional for apps; I have introduced a trivial `#valid?` method on `EventSourcery::Event` to ensure this change is backwards compatible.

Our app uses [dry-validation](https://github.com/dry-rb/dry-validation) for defining and enforcing the schemas, but that particular mechanism is not enforced here. It is only necessary for events to understand `#valid?` and provide a hash via `#validation_errors`

### Build Failure

This build is failing because my change relies on 
[this change to Event Sourcery](https://github.com/envato/event_sourcery/pull/174). Once that is merged this build will pass.