### PR TITLE
Only send info log after processing a group of events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
 
+- Only send info log after processing a group of events
 
 ## [0.5.0] - 2017-7-27
 - First Version of YARD documentation.

--- a/lib/event_sourcery/postgres/projector.rb
+++ b/lib/event_sourcery/postgres/projector.rb
@@ -33,8 +33,8 @@ module EventSourcery
               tracker.processed_event(processor_name, event.id)
             end
             EventSourcery.logger.debug { "[#{processor_name}] Processed event: #{event.inspect}" }
-            EventSourcery.logger.info { "[#{processor_name}] Processed up to event id: #{events.last.id}" }
           end
+          EventSourcery.logger.info { "[#{processor_name}] Processed up to event id: #{events.last.id}" }
         end
       end
     end

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -188,5 +188,26 @@ RSpec.describe EventSourcery::Postgres::Projector do
         expect(db_connection[:profiles].count).to eq 0
       end
     end
+
+    describe 'logging' do
+      it 'logs debug messages for each processed event' do
+        expect(EventSourcery.logger).to receive(:debug) do |&block|
+          expect(block.call).to eq "[test_processor] Processed event: #{events[0].inspect}"
+        end
+        expect(EventSourcery.logger).to receive(:debug) do |&block|
+          expect(block.call).to eq "[test_processor] Processed event: #{events[1].inspect}"
+        end
+
+        projector.subscribe_to(event_store, subscription_master: subscription_master)
+      end
+
+      it 'logs an info message with the id of the last processed event' do
+        expect(EventSourcery.logger).to receive(:info) do |&block|
+          expect(block.call).to eq "[test_processor] Processed up to event id: 2"
+        end
+
+        projector.subscribe_to(event_store, subscription_master: subscription_master)
+      end
+    end
   end
 end

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe EventSourcery::Postgres::Projector do
     end
 
     context 'when an error occurs processing the event' do
-
       it 'rolls back the projected changes' do
         projector.raise_error = true
         projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil


### PR DESCRIPTION
This matches the behaviour of [EventStreamProcessor][1] in event_sourcery.

We're using the block form of log which makes the testing slightly more verbose but means we don't need to evaluate the string if the logging level doesn't require the message to be logged.

[1]: https://github.com/envato/event_sourcery/blob/87d2dae6d18a460a2a6e69cbb315ea08863695d8/lib/event_sourcery/event_processing/event_stream_processor.rb#L155-L163