### PR TITLE
Resolve Ruby Warnings

### DIFF
--- a/lib/event_sourcery/postgres/config.rb
+++ b/lib/event_sourcery/postgres/config.rb
@@ -1,19 +1,21 @@
 module EventSourcery
   module Postgres
     class Config
-      attr_accessor :event_store_database,
-                    :lock_table_to_guarantee_linear_sequence_id_growth,
+      attr_accessor :lock_table_to_guarantee_linear_sequence_id_growth,
                     :write_events_function_name,
                     :events_table_name,
                     :aggregates_table_name,
                     :tracker_table_name,
                     :callback_interval_if_no_new_events,
                     :auto_create_projector_tracker,
-                    :event_tracker,
-                    :projections_database,
-                    :event_store,
-                    :event_source,
-                    :event_sink
+                    :event_tracker
+
+      attr_writer :event_store,
+                  :event_source,
+                  :event_sink
+
+      attr_reader :event_store_database,
+                  :projections_database
 
       def initialize
         @lock_table_to_guarantee_linear_sequence_id_growth = true

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe EventSourcery::Postgres::EventStore do
           event_id = Integer(payload)
         end
       end
+      expect(event_id).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Ruby produces several warnings while running our test suite:
https://travis-ci.org/envato/event_sourcery-postgres/jobs/322722599

This change set resolves these warnings:

```
event_sourcery-postgres/lib/event_sourcery/postgres/config.rb:29: warning: method redefined; discarding old event_store
event_sourcery-postgres/lib/event_sourcery/postgres/config.rb:33: warning: method redefined; discarding old event_source
event_sourcery-postgres/lib/event_sourcery/postgres/config.rb:37: warning: method redefined; discarding old event_sink
event_sourcery-postgres/lib/event_sourcery/postgres/config.rb:41: warning: method redefined; discarding old event_store_database=
event_sourcery-postgres/lib/event_sourcery/postgres/config.rb:47: warning: method redefined; discarding old projections_database=
event_sourcery-postgres/spec/event_sourcery/postgres/event_store_spec.rb:11: warning: assigned but unused variable - event_id
```
