### PR TITLE
Remove version restriction on Sequel gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - Remove `processes_events` and `projects_events` as these have been [removed
   in event_sourcery](https://github.com/envato/event_sourcery/pull/161).
-  - Remove restriction on `sequel` gem dependency version. Now accepts versions
+  - Remove upperbound version restriction on `sequel` gem. Now accepts versions
     5 and higher.
 
 ## [0.5.0] - 2017-7-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - Remove `processes_events` and `projects_events` as these have been [removed
   in event_sourcery](https://github.com/envato/event_sourcery/pull/161).
+  - Remove restriction on `sequel` gem dependency version. Now accepts versions
+    5 and higher.
 
 ## [0.5.0] - 2017-7-27
 - First Version of YARD documentation.

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_dependency 'sequel'
+  spec.add_dependency 'sequel', '>= 4.38'
   spec.add_dependency 'pg'
   spec.add_dependency 'event_sourcery', '>= 0.14.0'
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_dependency 'sequel', '~> 4.38'
+  spec.add_dependency 'sequel'
   spec.add_dependency 'pg'
   spec.add_dependency 'event_sourcery', '>= 0.14.0'
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
Version 5.3 of the Sequel gem has been released. The specs pass on this new version.

Anyone have concerns about removing this restriction?