### PR TITLE
Allow specifying a transaction size when projecting multiple events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add a `projector_transaction_size` config option to control how many events
+  are processed before the transaction is commited. The default value is 1 to
+  match the existing behavour.
+
+  We suggest setting this to match the number of events returned from the event
+  store subscription. This is [now configurable](https://github.com/envato/event_sourcery/pull/197)
+  in event_sourcery by configuring `subscription_batch_size`.
 
 ### Removed
 - Remove upper bound version restriction on `sequel` gem. Now accepts versions

--- a/lib/event_sourcery/postgres/config.rb
+++ b/lib/event_sourcery/postgres/config.rb
@@ -8,7 +8,8 @@ module EventSourcery
                     :tracker_table_name,
                     :callback_interval_if_no_new_events,
                     :auto_create_projector_tracker,
-                    :event_tracker
+                    :event_tracker,
+                    :projector_transaction_size
 
       attr_writer :event_store,
                   :event_source,
@@ -26,6 +27,7 @@ module EventSourcery
         @callback_interval_if_no_new_events = 10
         @event_store_database = nil
         @auto_create_projector_tracker = true
+        @projector_transaction_size = 1
       end
 
       def event_store

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
 
         attr_accessor :raise_error
 
-        process TermsAccepted do |event|
+        process do |event|
           table.insert(user_uuid: event.aggregate_id,
                        terms_accepted: true)
           raise 'boo' if raise_error

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe EventSourcery::Postgres::Projector do
   end
 
   describe '#project' do
-    let(:event) { new_event(type: :terms_accepted) }
+    let(:event) { ItemAdded.new }
 
     it 'processes events with custom classes' do
       projector = new_projector do
@@ -86,8 +86,9 @@ RSpec.describe EventSourcery::Postgres::Projector do
           @processed_event = event
         end
       end
-      event = ItemAdded.new
+
       projector.project(event)
+
       expect(projector.processed_event).to eq(event)
     end
   end

--- a/spec/event_sourcery/postgres/projector_spec.rb
+++ b/spec/event_sourcery/postgres/projector_spec.rb
@@ -37,10 +37,12 @@ RSpec.describe EventSourcery::Postgres::Projector do
     end.new(tracker: tracker, db_connection: db_connection)
   end
 
+  let(:projector_transaction_size) { 1 }
   subject(:projector) do
     projector_class.new(
       tracker: tracker,
-      db_connection: db_connection
+      db_connection: db_connection,
+      transaction_size: projector_transaction_size,
     )
   end
   let(:aggregate_id) { SecureRandom.uuid }
@@ -118,12 +120,12 @@ RSpec.describe EventSourcery::Postgres::Projector do
           column :terms_accepted, 'BOOLEAN DEFAULT FALSE'
         end
 
-        attr_accessor :raise_error
+        attr_accessor :raise_error, :raise_error_on_event_id
 
         process do |event|
           table.insert(user_uuid: event.aggregate_id,
                        terms_accepted: true)
-          raise 'boo' if raise_error
+          raise 'boo' if raise_error || raise_error_on_event_id == event.id
         end
       end
     end
@@ -141,6 +143,24 @@ RSpec.describe EventSourcery::Postgres::Projector do
     context 'when an error occurs processing the event' do
       it 'rolls back the projected changes' do
         projector.raise_error = true
+        projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil
+        expect(db_connection[:profiles].count).to eq 0
+      end
+    end
+
+    context 'with a transaction size of 1' do
+      it 'rolls back the projected changes for the single event' do
+        projector.raise_error_on_event_id = 2
+        projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil
+        expect(db_connection[:profiles].count).to eq 1
+      end
+    end
+
+    context 'with a transaction size of 2' do
+      let(:projector_transaction_size) { 2 }
+
+      it 'rolls back the projected changes for both events' do
+        projector.raise_error_on_event_id = 2
         projector.subscribe_to(event_store, subscription_master: subscription_master) rescue nil
         expect(db_connection[:profiles].count).to eq 0
       end


### PR DESCRIPTION
The process_events method may be called with 1 or more events. It then loops through each event, opens a transaction and processes the event.

This change allows specifying the number of events to process before closing the transaction.

Processing more events inside the transactions should lead to speed increases in most cases.

#### TODO

- [x] Changelog Entry