### PR TITLE
Don't report thread exceptions in spec when using Ruby 2.5+

### DIFF
--- a/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
+++ b/spec/event_sourcery/postgres/optimised_event_poll_waiter_spec.rb
@@ -46,9 +46,11 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
     end
 
     it 'raise an error' do
-      expect {
-        waiter.poll {}
-      }.to raise_error(described_class::ListenThreadDied)
+      quiet_thread_report_on_exception do
+        expect {
+          waiter.poll {}
+        }.to raise_error(described_class::ListenThreadDied)
+      end
     end
   end
 
@@ -79,6 +81,19 @@ RSpec.describe EventSourcery::Postgres::OptimisedEventPollWaiter do
           throw :stop
         end
       end
+    end
+  end
+
+  def quiet_thread_report_on_exception(&block)
+    if Thread.respond_to?(:report_on_exception)
+      orig_report_on_exception = Thread.report_on_exception
+      Thread.report_on_exception = false
+
+      block.call
+
+      Thread.report_on_exception = orig_report_on_exception
+    else
+      block.call
     end
   end
 end


### PR DESCRIPTION
Ruby 2.5.0 changed the default of Thread.report_on_exception to true. This thread is meant to raise an exception.

https://bugs.ruby-lang.org/issues/14143