### PR TITLE
Add project metadata URIs to the gem spec

### DIFF
--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -12,6 +12,11 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Postgres event store for use with EventSourcery'
   spec.homepage      = 'https://github.com/envato/event_sourcery-postgres'
+  spec.metadata      = {
+                         'bug_tracker_uri' => 'https://github.com/envato/event_sourcery-postgres/issues',
+                         'changelog_uri'   => 'https://github.com/envato/event_sourcery-postgres/blob/master/CHANGELOG.md',
+                         'source_code_uri' => 'https://github.com/envato/event_sourcery-postgres',
+                       }
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(\.|bin/|Gemfile|Rakefile|script/|spec/)})


### PR DESCRIPTION
Following on from envato/event_sourcery#205. Add project metadata URIs to the gem spec. This makes more information available via the RubyGems API which in turn helps automated tools like Unwrappr obtain information about the project and individual releases.

https://guides.rubygems.org/specification-reference/#metadata