### PR TITLE
Introduce on_events_recoded hook to config and EventStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.0]
+###
+- Add a `on_events_recorded` config option, that defaults to a no-op proc, \
+  to handle any app specific logic after the events are recoded on `EventStore#sink`
+
 ## [0.7.0] - 2018-05-23
 ### Added
 - Add a `projector_transaction_size` config option to control how many events

--- a/lib/event_sourcery/postgres/config.rb
+++ b/lib/event_sourcery/postgres/config.rb
@@ -9,7 +9,8 @@ module EventSourcery
                     :callback_interval_if_no_new_events,
                     :auto_create_projector_tracker,
                     :event_tracker,
-                    :projector_transaction_size
+                    :projector_transaction_size,
+                    :on_events_recorded
 
       attr_writer :event_store,
                   :event_source,
@@ -28,6 +29,7 @@ module EventSourcery
         @event_store_database = nil
         @auto_create_projector_tracker = true
         @projector_transaction_size = 1
+        @on_events_recorded = ->(events) {}
       end
 
       def event_store

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/spec/event_sourcery/postgres/event_store_spec.rb
+++ b/spec/event_sourcery/postgres/event_store_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe EventSourcery::Postgres::EventStore do
   include_examples 'an event store'
 
   describe '#sink' do
+    let(:on_events_recorded_proc) { double("OnEventsRecordedProc", call: nil) }
+
+    before do
+      allow(EventSourcery::Postgres.config)
+        .to receive(:on_events_recorded)
+        .and_return(on_events_recorded_proc)
+    end
+
     it 'notifies about a new event' do
       event_id = nil
       Timeout.timeout(1) do
@@ -14,7 +22,9 @@ RSpec.describe EventSourcery::Postgres::EventStore do
           event_id = Integer(payload)
         end
       end
+
       expect(event_id).not_to be_nil
+      expect(on_events_recorded_proc).to have_received(:call)
     end
   end
 


### PR DESCRIPTION
This PR introduces the `on_events_recorded` hook to the Config class.

This hook will run on as the last thing on `EventStore#sink`  and can be used to do any work specific to your application when the events are recorded to the event store. Eg, passing stats to Datadog or any other service like that.

Once this PR is approved I add a commit to bump the version and update the Changelog.