### PR TITLE
Test on Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.3
 - 2.4
 - 2.5
+- 2.6
 before_install:
 - gem install bundler
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add Ruby 2.6 to the CI test matrix.
+
 ## [0.8.0]
 ###
 - Add a `on_events_recorded` config option, that defaults to a no-op proc, \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Ruby 2.6 to the CI test matrix.
 
 ## [0.8.0]
-###
+### Added
 - Add a `on_events_recorded` config option, that defaults to a no-op proc, \
   to handle any app specific logic after the events are recoded on `EventStore#sink`
 
@@ -79,7 +79,9 @@ or when the loop stops
 - Postgres related configuration is through `EventSourcery::Postgres.configure`
   instead of `EventSourcery.configure`.
 
-[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
Ruby 2.6 has been [released](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/)! Let's add it to the test matrix.

![image](https://user-images.githubusercontent.com/497874/50582692-6dc66280-0eb8-11e9-9384-9e03e3568305.png)
