### PR TITLE
Fix the CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2
 - 2.3
 - 2.4
 - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.4
 - 2.5
 before_install:
+- gem update --system
 - gem install bundler
 before_script:
 - psql -c 'create database event_sourcery_test;' -U postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Removed
+- Remove Ruby 2.2 from the CI test matrix.
+
 ## [0.8.0]
 ###
 - Add a `on_events_recorded` config option, that defaults to a no-op proc, \

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sequel', '>= 4.38'
   spec.add_dependency 'pg'
   spec.add_dependency 'event_sourcery', '>= 0.14.0'
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Since Bundler 2.0 was released, our build has failed:

![image](https://user-images.githubusercontent.com/497874/50671600-fa8f2e80-1026-11e9-9e8a-caa856a909b9.png)


In our CI we install the [latest version of Bundler (2.0.1)](https://travis-ci.org/envato/event_sourcery-postgres/jobs/475125992#L472), but our gemspec [specifies we must use `~> 1.10`](https://travis-ci.org/envato/event_sourcery-postgres/jobs/475125992#L481) which excludes version 2.

To fix this:

* remove the constraint on the Bundler version from the gemspec
* ensure the latest version of Rubygems is installed, and
* remove Ruby 2.2 from the build matrix (Bundler 2.0 is not available on this version of Ruby)

![image](https://user-images.githubusercontent.com/497874/50671607-07138700-1027-11e9-8d6f-7c18b26556a6.png)

