### PR TITLE
Add default value constraint for uuid primary key

### DIFF
--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -53,7 +53,7 @@ module EventSourcery
       def create_aggregates(db: EventSourcery::Postgres.config.event_store_database,
                             table_name: EventSourcery::Postgres.config.aggregates_table_name)
         db.create_table(table_name) do
-          primary_key :aggregate_id, :uuid
+          uuid :aggregate_id, primary_key: true
           column :version, :bigint, default: 1
         end
       end


### PR DESCRIPTION
I'm just getting started with building an application with event sourcery and had the following error when creating the database. I'm using Postgres 11 and the following error is generated when trying to create the aggregates table unless a default constraint is added.

Thanks for open sourcing all the hard work y'all have done. Reading through the readmes and example application I'm looking forward to trying it out.

```
Sequel::DatabaseError:
  PG::InvalidParameterValue: ERROR:  identity column type must be smallint, integer, or bigint
```