### PR TITLE
Update Rake to version 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.
 
+### Fixed
+- Upgrade development dependency Rake to version 13. This resolves
+  [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).
+
 ## [0.8.0]
 ### Added
 - Add a `on_events_recorded` config option, that defaults to a no-op proc, \

--- a/event_sourcery-postgres.gemspec
+++ b/event_sourcery-postgres.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pg'
   spec.add_dependency 'event_sourcery', '>= 0.14.0'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
This resolves the security issue: CVE-2020-8130.