### PR TITLE
Only send slack notifications for builds on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   postgresql: 9.4
 notifications:
   slack:
+    if: branch = master
     on_pull_requests: false
     on_success: change
     on_failure: always


### PR DESCRIPTION
We're only interesting in build failures when they occur on the `master` branch.

Disable Slack for all but the `master` branch.

[TravisCI condition documentation](https://config.travis-ci.com/ref/job/if/condition)