### PR TITLE
Resolve Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 before_install:
 - gem update --system
 - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade development dependency Rake to version 13. This resolves
   [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).
 
+- Resolve warnings raised when running on Ruby 2.7.
+
 ## [0.8.0]
 ### Added
 - Add a `on_events_recorded` config option, that defaults to a no-op proc, \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Add Ruby 2.6 to the CI test matrix.
+- Add Ruby 2.6 and 2.7 to the CI test matrix.
 
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -60,7 +60,7 @@ module EventSourcery
           where(Sequel.lit('id >= ?', id)).
           limit(limit)
         query = query.where(type: event_types) if event_types
-        query.map { |event_row| build_event(event_row) }
+        query.map { |event_row| build_event(**event_row) }
       end
 
       # Get last event id for a given event types.
@@ -86,7 +86,7 @@ module EventSourcery
       # @return [Array] of found events
       def get_events_for_aggregate_id(aggregate_id)
         events_table.where(aggregate_id: aggregate_id.to_str).order(:version).map do |event_hash|
-          build_event(event_hash)
+          build_event(**event_hash)
         end
       end
 
@@ -107,7 +107,7 @@ module EventSourcery
           subscription_master: subscription_master,
           on_new_events: block
         }
-        EventSourcery::EventStore::Subscription.new(args).tap(&:start)
+        EventSourcery::EventStore::Subscription.new(**args).tap(&:start)
       end
 
       private
@@ -118,8 +118,8 @@ module EventSourcery
         @db_connection[@events_table_name]
       end
 
-      def build_event(data)
-        @event_builder.build(data)
+      def build_event(**data)
+        @event_builder.build(**data)
       end
 
       def write_events_sql(aggregate_id, events, expected_version)


### PR DESCRIPTION
Resolve the following warnings raised when running on Ruby 2.7.

```
/event_sourcery-postgres/lib/event_sourcery/postgres/event_store.rb:122: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/event_sourcery-4ac4f7c83b32/lib/event_sourcery/event_store/event_builder.rb:8: warning: The called method `build' is defined here

/event_sourcery-postgres/lib/event_sourcery/postgres/event_store.rb:110: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/ruby/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/event_sourcery-4ac4f7c83b32/lib/event_sourcery/event_store/subscription.rb:15: warning: The called method `initialize' is defined here