### PR TITLE
Replace "type" index with multi-column index on "id" and "type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+
+- The `events` table `type` modified to include both `id` and `type` ([#69]).
+  - This change should not affect existing applications. However, it is **recommended** to apply similar changes to the `events` table by adding a new index.
+  - To create a new index, the following SQL could be executed manually on event store database:
+    ```sql
+    CREATE INDEX events_id_type_index ON events ("id", "type");
+    ```
+    Keep in mind that creating a new index will lock the table. To prevent that, you can use the following SQL:
+    ```sql
+    CREATE INDEX CONCURRENTLY events_id_type_index ON events ("id", "type");
+    ```
+    Read more about creating index on [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createindex.html).
+  - (optional) To drop the existing `type` index, the following SQL could be executed manually on event store database:
+    ```sql
+    DROP INDEX events_type_index;
+    ```
+    Note that you might need to keep this index if you have a custom script that uses the index.
+  - _The above queries are suggestion so feel free to modify existing indexes as you wish._
+
 ## [0.9.0] - 2021-11-18
 
 ### Added

--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -38,7 +38,7 @@ module EventSourcery
           column :created_at,     :'timestamp without time zone', null: false, default: Sequel.lit("(now() at time zone 'utc')")
           index [:aggregate_id, :version], unique: true
           index :uuid, unique: true
-          index :type
+          index [:id, :type]
           index :correlation_id
           index :causation_id
           index :created_at


### PR DESCRIPTION
## Context

With the current design, every time a new event is stored in the database, every projector/reactor will receive a signal from PostgreSQL and eventually they will query the database for new events despite the fact that the new event *could be* irrelevant to them. As a result, queries like this:  
```sql
SELECT * FROM "events" WHERE ((id >= ?) AND ("type" IN (?))) ORDER BY "id" LIMIT ?
```
will be executed multiple times. Fixing this issue won't be very simple and requires changes in both event sourcery and this gem. However, we could modify the existing index on the `events.type` column and make it a multi-column index on both `events.id` and `events.type`. Although this change will not fix the issue entirely, it will improve the event sourcery performance significantly.

Adding the above index will have impact on [EventSourcery::Postgres::EventStore#get_next_from](https://github.com/envato/event_sourcery-postgres/blob/324da921004f01e8618378ff5b4ad18b3032daf1/lib/event_sourcery/postgres/event_store.rb#L57-L64) method performance.

## Recent investigation

In the recent investigation, we've found out that having a multi-column index for both `events.id` and `events.type` columns on the events table could improve performance significantly. We processed around 3M events on the same AWS RDS instance multiple times, here is the result:

Process duration before adding the index: 264 minutes
Process duration after adding the index:  103 minutes

## Questions

### What needs to be done for existing apps?

We can use [gemspec post-install message](https://guides.rubygems.org/specification-reference/#post_install_message) to notify the existing applications about the change. At the moment, the event-sourcery gem does not provide a "migration" command so it would be better to help them by providing a SQL query for modifying the index. The documentation regarding creating a new index exists in the CHANGELOG.md file and that could be enough too.

### Would this change would solve all performance issues?
No. There are other parts of the system that should be fixed or improved. For example, I can think of the following ideas:
- Better polling mechanism to trigger loading events only when the newly created event is watched by the event processor (reactors/projectors).
- Time-based polling for applications that do not require real-time event processing
- Configurable event poller that supports native Postgres and Redis pub/sub.

### Why not just add another index?
I was not able to find a query for the `events.type` column alone so I don't see any benefit for adding a new index when the existing one is not used.

