### PR TITLE
Remove Ruby 2.3, 2.4 and 2.5 from the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This project now uses `main` as its default branch ([#68]).
   - Documentation updated to refer to `main` and links updated accordingly.
 
+### Removed
+- Remove Ruby 2.3, 2.4 and 2.5 from the CI test matrix ([#70]).
+
 [#66]: https://github.com/envato/event_sourcery-postgres/pull/66
 [#67]: https://github.com/envato/event_sourcery-postgres/pull/67
 [#68]: https://github.com/envato/event_sourcery-postgres/pull/68
+[#70]: https://github.com/envato/event_sourcery-postgres/pull/70
 
 ## [0.8.1] - 2020-10-02
 ### Added


### PR DESCRIPTION
### Context

Ruby 2.3, 2.4 and 2.5 have reached their EOL. 
We removing dropping test matrixes for those ruby versions.

### Considaration

- We were unable to find an Envato application using this gem with one of the above ruby versions
- We will reach out to Envato engineering before releasing a new gem
- A new version will be released in the next  PR