### PR TITLE
Bump version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [0.9.0] - 2021-11-18
+
 ### Added
 
 - Test against Ruby 3.0 in the CI build ([#67]).
@@ -108,7 +110,8 @@ or when the loop stops
 - Postgres related configuration is through `EventSourcery::Postgres.configure`
   instead of `EventSourcery.configure`.
 
-[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.6.0...v0.7.0

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = '0.8.1'.freeze
+    VERSION = '0.9.0'.freeze
   end
 end


### PR DESCRIPTION
Bump the new version 0.9.0. The changelog is already up to date.

We will be following the "[release](https://github.com/envato/event_sourcery#release)" document for releasing the new gem version.