### PR TITLE
deprecated last arg keyword param event store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+
+- Removed the use of `**` for the private `EventStore#build_event`
+  method signature and places that call it.
+
 ## [0.9.0] - 2021-11-18
 
 ### Added

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -118,7 +118,7 @@ module EventSourcery
         @db_connection[@events_table_name]
       end
 
-      def build_event(**data)
+      def build_event(data)
         @event_builder.build(**data)
       end
 

--- a/lib/event_sourcery/postgres/event_store.rb
+++ b/lib/event_sourcery/postgres/event_store.rb
@@ -60,7 +60,7 @@ module EventSourcery
           where(Sequel.lit('id >= ?', id)).
           limit(limit)
         query = query.where(type: event_types) if event_types
-        query.map { |event_row| build_event(**event_row) }
+        query.map { |event_row| build_event(event_row) }
       end
 
       # Get last event id for a given event types.
@@ -86,7 +86,7 @@ module EventSourcery
       # @return [Array] of found events
       def get_events_for_aggregate_id(aggregate_id)
         events_table.where(aggregate_id: aggregate_id.to_str).order(:version).map do |event_hash|
-          build_event(**event_hash)
+          build_event(event_hash)
         end
       end
 


### PR DESCRIPTION
We are working on clearing out the deprecation warnings for our app as we've moved to ruby 2.7 and are getting ready for 3.x. During the process we had the following warning show up...

```bash
/app/vendor/bundle/ruby/2.7.0/gems/sequel-5.52.0/lib/sequel/dataset/actions.rb:150: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/vendor/bundle/ruby/2.7.0/gems/event_sourcery-postgres-0.9.0/lib/event_sourcery/postgres/event_store.rb:121: warning: The called method `build_event' is defined here
```

Forgive me if I've got this one wrong but the `**` in the line `def build_event(**data)` is used to convert keyword arguments passed to (like `build_event(foo: 1, bar: 2)`) it to a single hash variable ((like `{ foo: 1, bar: 2 }`). I am not sure how many things are expected to call the `build_event` method here but the [sequel method that calls this](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/dataset/actions.rb#L150) already sends a hash to the method so the `**` has no effect (presumably).

As far as I can tell [this would break in ruby 3.0](https://rubyreferences.github.io/rubychanges/2.7.html#keyword-argument-related-changes) unless it is changed. 
