### PR TITLE
Bump version 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [0.9.1] - 2022-01-20
 
 ### Changed
 
@@ -116,7 +117,8 @@ or when the loop stops
 - Postgres related configuration is through `EventSourcery::Postgres.configure`
   instead of `EventSourcery.configure`.
 
-[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery-postgres/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/envato/event_sourcery-postgres/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/envato/event_sourcery-postgres/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/envato/event_sourcery-postgres/compare/v0.7.0...v0.8.0

--- a/lib/event_sourcery/postgres/version.rb
+++ b/lib/event_sourcery/postgres/version.rb
@@ -1,5 +1,5 @@
 module EventSourcery
   module Postgres
-    VERSION = '0.9.0'.freeze
+    VERSION = '0.9.1'.freeze
   end
 end


### PR DESCRIPTION
Bump the new version 0.9.1. The changelog is already up to date.

We will be following the "[release](https://github.com/envato/event_sourcery#release)" document for releasing the new gem version.